### PR TITLE
Feature: Set sync start date

### DIFF
--- a/.env_public
+++ b/.env_public
@@ -3,6 +3,7 @@ ACTUAL_BUDGET_PASSWORD=
 ACTUAL_BUDGET_SERVER_URL=# http://localhost:5006
 ACTUAL_BUDGET_UP_ACCOUNT_ID=
 ACTUAL_BUDGET_ENCRYPTION_PASSWORD= # Only Required if budget file has end-to-end encryption enabled
+UP_BANK_SYNC_START=# Date & time in rfc-3339 format YYYY-MM-DDTHH:MM:SS[Z or +HH:MM]
 
 # left is up id, right is actual budget id
 UP_ACCOUNT_MAPPING='{

--- a/BankAPICollect/src/functions/GetBankTransactions.js
+++ b/BankAPICollect/src/functions/GetBankTransactions.js
@@ -60,6 +60,11 @@ async function getBudgetAccounts() {
 async function fetchTransactionsForAccount(accountId, accessToken) {
   let allTransactions = [];
   let nextPageUrl = `https://api.up.com.au/api/v1/accounts/${accountId}/transactions`;
+  
+  let syncStart = process.env.UP_BANK_SYNC_START;
+  if (typeof syncStart === 'undefined' || syncStart == ""){
+    syncStart = "2015-01-01T00:00:00Z" // Start date that will cover all transactions
+  }
 
   try {
     while (nextPageUrl) {
@@ -68,7 +73,8 @@ async function fetchTransactionsForAccount(accountId, accessToken) {
           'Authorization': `Bearer ${accessToken}`
         },
         params: {
-          'page[size]': 100  // Adjust size as needed
+          'page[size]': 100,  // Adjust size as needed
+          'filter[since]' : syncStart
         }
       });
 

--- a/BankAPICollect/src/functions/GetBankTransactions.js
+++ b/BankAPICollect/src/functions/GetBankTransactions.js
@@ -233,7 +233,8 @@ async function fetchDateRangeTransactionsForAccount(accountId, accessToken, sinc
                     'Authorization': `Bearer ${accessToken}`
                 },
                 params: {
-                    'page[size]': 100  // Increased page size
+                    'page[size]': 100,  // Increased page size
+                    'filter[since]' : since
                 }
             });
 
@@ -261,6 +262,19 @@ async function fetchTransactionsForPastWeek(connection) {
 
         // Calculate the date for past one week
         const OneWeekAgo = new Date(Date.now() - 24 * 7 * 60 * 60 * 1000).toISOString();
+        const syncStart = process.env.UP_BANK_SYNC_START;
+        let maxPullDate;
+
+        // Check if syncStart date is after OneWeekAgo
+        if (typeof syncStart === 'undefined' || syncStart == ""){
+            maxPullDate = OneWeekAgo;
+        } else {
+            if (syncStart > OneWeekAgo){
+                maxPullDate = syncStart;
+            } else {
+                maxPullDate = OneWeekAgo;
+            }
+        }
 
         for (const account of accounts) {
             //console.log(`Fetching transactions for account: ${account.attributes.displayName}`);
@@ -269,7 +283,7 @@ async function fetchTransactionsForPastWeek(connection) {
                 const transactions = await fetchDateRangeTransactionsForAccount(
                     account.id,
                     accessToken,
-                    OneWeekAgo
+                    maxPullDate
                 );
 
                 allTransactions = [...allTransactions, ...transactions];

--- a/BankAPICollect/src/functions/GetBankTransactions.js
+++ b/BankAPICollect/src/functions/GetBankTransactions.js
@@ -62,6 +62,7 @@ async function fetchTransactionsForAccount(accountId, accessToken) {
   let nextPageUrl = `https://api.up.com.au/api/v1/accounts/${accountId}/transactions`;
   
   let syncStart = process.env.UP_BANK_SYNC_START;
+  // Check if syncStart is set
   if (typeof syncStart === 'undefined' || syncStart == ""){
     syncStart = "2015-01-01T00:00:00Z" // Start date that will cover all transactions
   }
@@ -74,7 +75,7 @@ async function fetchTransactionsForAccount(accountId, accessToken) {
         },
         params: {
           'page[size]': 100,  // Adjust size as needed
-          'filter[since]' : syncStart
+          'filter[since]': syncStart  // Date filter
         }
       });
 
@@ -234,7 +235,7 @@ async function fetchDateRangeTransactionsForAccount(accountId, accessToken, sinc
                 },
                 params: {
                     'page[size]': 100,  // Increased page size
-                    'filter[since]' : since
+                    'filter[since]': since  // Date filter
                 }
             });
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ACTUAL_BUDGET_PASSWORD="your_password"
 UP_BANK_ACCESS_TOKEN="your_up_api_key"
 ACTUAL_BUDGET_SERVER_URL="http://localhost:5006"  # Change if hosted
 ACTUAL_BUDGET_ENCRYPTION_PASSWORD="your_E2E_encryption_password"
+UP_BANK_SYNC_START="your_sync_start_date" # Date & time in rfc-3339 format YYYY-MM-DDTHH:MM:SS[Z or +HH:MM]
 ```
 
 ### 5. Run the container to get your accound ID's

--- a/autorun.sh
+++ b/autorun.sh
@@ -5,6 +5,7 @@ export ACTUAL_BUDGET_PASSWORD=
 export ACTUAL_BUDGET_SERVER_URL=    # http://localhost:5006
 export ACTUAL_BUDGET_UP_ACCOUNT_ID=
 export ACTUAL_BUDGET_ENCRYPTION_PASSWORD= # Only Required if budget file has end-to-end encryption enabled
+export UP_BANK_SYNC_START= # Date & time in rfc-3339 format YYYY-MM-DDTHH:MM:SS[Z or +HH:MM]
 
 # left is up id, right is actual budget id
 export UP_ACCOUNT_MAPPING='{


### PR DESCRIPTION
This updates allows the application to limit transactions fetched from up to be after a specified data.
The date is specified in the following environment variable 
`UP_BANK_SYNC_START ` it must be in the rfc-3339 format [as specified by up](https://developer.up.com.au/#get_transactions) YYYY-MM-DDTHH:MM:SS[Z or +HH:MM]
 e.g. 2025-01-05T10:15:00+11:00 would be 05 Jan 2025 at 10:15am AEDT (UTC+11)

- A check incase the variable is not set or is blank is included in which case 2015-01-01T00:00:00Z is used so that all transactions are pulled
- Checks included so that during fetching transactions for the past week, if that is before the specified sync start date then the sync start date will be used instead. I.e. if yesterday's date was used as the sync start date then only transactions that occurred today or yesterday will be imported.