### PR TITLE
Add transaction id to actual to avoid false deduplication

### DIFF
--- a/BankAPICollect/src/functions/GetBankTransactions.js
+++ b/BankAPICollect/src/functions/GetBankTransactions.js
@@ -183,6 +183,7 @@ async function uploadTransactions(accounts) {
                 date: new Date(transaction.attributes.settledAt || transaction.attributes.createdAt).toISOString().split('T')[0],
                 amount: Math.round(transaction.attributes.amount.value * 100),
                 payee_name: transaction.attributes.description || 'Unknown',
+                imported_id: transaction.id,
               };
 
               if (roundUpAmount !== 0) {
@@ -376,6 +377,7 @@ async function uploadWeeklyTransactions(weeklyTransactions) {
                 date: new Date(transaction.attributes.settledAt || transaction.attributes.createdAt).toISOString().split('T')[0],
                 amount: Math.round(transaction.attributes.amount.value * 100),
                 payee_name: transaction.attributes.description || 'Unknown',
+                imported_id: transaction.id,
               };
 
               if (roundUpAmount !== 0) {


### PR DESCRIPTION
This pull request adds the transaction id from the UP API, to the transaction that is created in Actual Budget.
This is required as the deduplication logic will see transaction on different days with the same payee and amount as duplicates without the imported_id field to differentiate.
Eg. Buying coffee each day. Transactions on Multiple days will be skipped.
