### PR TITLE
Cleared Status on Import

### DIFF
--- a/BankAPICollect/src/functions/GetBankTransactions.js
+++ b/BankAPICollect/src/functions/GetBankTransactions.js
@@ -199,6 +199,7 @@ async function uploadTransactions(accounts) {
                             payee: targetPayee.id,
                             payee_name: transaction.attributes.description || 'Unknown',
                             imported_id: transaction.id,
+                            cleared: transaction.attributes.status === "SETTLED",
                         };
                         
                         // Additional Checks for special transfer types (roundup & forward / covers)
@@ -240,6 +241,7 @@ async function uploadTransactions(accounts) {
                 amount: Math.round(transaction.attributes.amount.value * 100),
                 payee_name: transaction.attributes.description || 'Unknown',
                 imported_id: transaction.id,
+                cleared: transaction.attributes.status === "SETTLED",
               };
 
               return [formattedTransaction]; // Return an array with a single item
@@ -442,6 +444,7 @@ async function uploadWeeklyTransactions(weeklyTransactions) {
                             payee: targetPayee.id,
                             payee_name: transaction.attributes.description || 'Unknown',
                             imported_id: transaction.id,
+                            cleared: transaction.attributes.status === "SETTLED",
                         };
                         
                         // Additional Checks for special transfer types (roundup & forward / covers)
@@ -483,6 +486,7 @@ async function uploadWeeklyTransactions(weeklyTransactions) {
                 amount: Math.round(transaction.attributes.amount.value * 100),
                 payee_name: transaction.attributes.description || 'Unknown',
                 imported_id: transaction.id,
+                cleared: transaction.attributes.status === "SETTLED",
               };
 
               return [formattedTransaction]; // Return an array with a single item


### PR DESCRIPTION
Added cleared status to import, so pending transactions are imported as uncleared and will be updated once settled.